### PR TITLE
add package dependency and services.json.orig

### DIFF
--- a/packageDependencies
+++ b/packageDependencies
@@ -1,2 +1,3 @@
 RpiGpioSetup  uninstalled
 GuiMods       installed
+RemoteGPIO_tcpip  uninstalled

--- a/setup
+++ b/setup
@@ -59,6 +59,7 @@ if [ $scriptAction == 'INSTALL' ] ; then
 	if [ $(dbus -y com.victronenergy.settings /Settings/System/ImageType GetValue) == 1 ]
 	then
 
+		cp /usr/lib/node_modules/@victronenergy/node-red-contrib-victron/src/services/services.json /usr/lib/node_modules/@victronenergy/node-red-contrib-victron/src/services/services.json.orig
 		patch /usr/lib/node_modules/@victronenergy/node-red-contrib-victron/src/services/services.json /data/RemoteGPIO/FileSets/PatchSource/services.json.patch
 		
 	fi

--- a/setup
+++ b/setup
@@ -59,7 +59,10 @@ if [ $scriptAction == 'INSTALL' ] ; then
 	if [ $(dbus -y com.victronenergy.settings /Settings/System/ImageType GetValue) == 1 ]
 	then
 
+		if [ ! -f /usr/lib/node_modules/@victronenergy/node-red-contrib-victron/src/services/services.json.orig ]
+		then
 		cp /usr/lib/node_modules/@victronenergy/node-red-contrib-victron/src/services/services.json /usr/lib/node_modules/@victronenergy/node-red-contrib-victron/src/services/services.json.orig
+		fi
 		patch /usr/lib/node_modules/@victronenergy/node-red-contrib-victron/src/services/services.json /data/RemoteGPIO/FileSets/PatchSource/services.json.patch
 		
 	fi


### PR DESCRIPTION
there is a small handful of people using a modified version of the old RemoteGPIO from my GitHub, so I have added that to the list of dependencies.
I have added to the setup script to create services.json.orig before services.json is patched, so that the original file can be restored from terminal if something goes bad. The .orig file will be located in /usr/lib/node_modules/@victronenergy/node-red-contrib-victron/src/services. Being located in this directory will insure that the .orig file will always be replaced with a new .orig file upon a firmware update.